### PR TITLE
optional post featured image

### DIFF
--- a/src/_includes/partials/card.njk
+++ b/src/_includes/partials/card.njk
@@ -1,7 +1,9 @@
 {% macro card(post) %}
     <a class="post-card{% if post.featured %}  post-card-featured{% endif %}" href="{{ post.url }}">
         <header class="post-card-header">
-            <img class="post-card-image" src="{{ post.feature_image }}" alt="{{ post.title }}">
+            {% if post.feature_image %}
+                <img class="post-card-image" src="{{ post.feature_image }}" alt="{{ post.title }}">
+            {% endif %}
             <div class="post-card-tags">
                 {% if post.tags %}{% for tag in post.tags %}{{ tag.name }} {% endfor %}{% endif %}
             </div>


### PR DESCRIPTION
Hi. When a card has no featured image, the feed breaks and shows an empty space where an image is supposed to be, like this: https://i.imgur.com/HRQpwil.png

The problem stems from this bit right here: https://github.com/TryGhost/eleventy-starter-ghost/blob/master/src/_includes/partials/card.njk#L4

I've tried out the fix with my own personal blog and the fix worked, as you can see here: https://i.imgur.com/etW4Jtw.png

Thank you.