### PR TITLE
Optionally display author profile image

### DIFF
--- a/src/_includes/partials/card.njk
+++ b/src/_includes/partials/card.njk
@@ -16,6 +16,7 @@
         </div>
         <footer class="post-card-footer">
             <div class="post-card-footer-left">
+                {% if post.primary_author.profile_image %}
                 <div class="post-card-avatar">
                     <img
                         class="author-profile-image"
@@ -23,6 +24,7 @@
                         alt="{{ post.primary_author.name }}"
                     />
                 </div>
+                {% endif %}
                 <span>{{ post.primary_author.name }}</span>
             </div>
             <div class="post-card-footer-right">


### PR DESCRIPTION
Updating `card.njk` to add an if wrapper so that the author profile photo only displays when that data exists. This should help anyone attempting to follow along with the eleventy/ghost tutorial with a fresh ghost install. By default, your admin user doesn't include a profile photo so when you create your first test post to see if you've configured the template correctly you get a super vague error message. 