### PR TITLE
Filter out internal tags in collection creation, fixes #35

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -150,7 +150,8 @@ module.exports = function(config) {
     collection = await api.tags
       .browse({
         include: "count.posts",
-        limit: "all"
+        limit: "all",
+        filter: "visibility:public"
       })
       .catch(err => {
         console.error(err);


### PR DESCRIPTION
Internal tags aren't needed when creating the tags collection, the collection is to help generate the tag pages. In most cases internal tags would be used to filter out certain posts in the template code, and are therefore only needed as an attribute on posts