### PR TITLE
Fix Netlify Integrations link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To deploy to your Netlify account, hit the button below.
 
 Content API Keys are generally not considered to be sensitive information, they exist so that they can be changed in the event of abuse; so most people commit it directly to their `.env` config file. If you prefer to keep this information out of your repository you can remove this config and set [Netlify ENV variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables) for production builds instead.
 
-Once deployed, you can set up a [Ghost + Netlify Integration](https://docs.ghost.org/integrations/netlify/) to use deploy hooks from Ghost to trigger Netlify rebuilds. That way, any time data changes in Ghost, your site will rebuild on Netlify.
+Once deployed, you can set up a [Ghost + Netlify Integration](https://ghost.org/integrations/netlify/) to use deploy hooks from Ghost to trigger Netlify rebuilds. That way, any time data changes in Ghost, your site will rebuild on Netlify. 
 
 # Optimising
 


### PR DESCRIPTION
Fix Netlify Integrations link

from https://docs.ghost.org/integrations/netlify/
to https://ghost.org/integrations/netlify/